### PR TITLE
Normalization is broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@
     // Replace any matches of "some/path/../" with "some/"
     while (prevPath !== path) {
       prevPath = path
-      path = path.replace(/([\w,\-]*[\/]{1,})([\.]{2,}\/)/g, '') // eslint-disable-line no-useless-escape
+      path = path.replace(/([\w,\-]+[\/]{1,})([\.]{2,}\/)/g, '') // eslint-disable-line no-useless-escape
     }
 
     // Replace any matches of multiple "/" with a single "/"


### PR DESCRIPTION
The regex that removes `/../` doesn't work when there is no letter before the first slash, for example in long chains such as `some/../../../thing` or empty segments `some//../thing`.

See this example:
https://regex101.com/r/oLomX6/1